### PR TITLE
Introduce ppcore module and refactor build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,3 +227,11 @@ add_subdirectory(src/tools/export-to-wav)
 
 # Set MilkyTracker target as startup project in Visual Studio
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tracker)
+
+# Add core libraries first
+add_subdirectory(src/ppcore)
+add_subdirectory(src/compression)
+add_subdirectory(src/fx)
+add_subdirectory(src/milkyplay)
+add_subdirectory(src/ppui)
+add_subdirectory(src/tracker)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ endif()
 
 add_subdirectory(docs)
 add_subdirectory(resources/music)
+add_subdirectory(src/ppcore)
 add_subdirectory(src/compression)
 add_subdirectory(src/fx)
 add_subdirectory(src/milkyplay)
@@ -227,11 +228,3 @@ add_subdirectory(src/tools/export-to-wav)
 
 # Set MilkyTracker target as startup project in Visual Studio
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tracker)
-
-# Add core libraries first
-add_subdirectory(src/ppcore)
-add_subdirectory(src/compression)
-add_subdirectory(src/fx)
-add_subdirectory(src/milkyplay)
-add_subdirectory(src/ppui)
-add_subdirectory(src/tracker)

--- a/src/compression/CMakeLists.txt
+++ b/src/compression/CMakeLists.txt
@@ -48,9 +48,16 @@ target_include_directories(compression
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../milkyplay
         ${CMAKE_CURRENT_SOURCE_DIR}/../ppui
         ${CMAKE_CURRENT_SOURCE_DIR}/../ppui/osinterface/posix
+        ${CMAKE_CURRENT_SOURCE_DIR}/../milkyplay
+        ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(compression
+    PRIVATE
+        ppcore
+        milkyplay
 )
 
 # Under macOS and Windows, build sources from Git submodules if present

--- a/src/compression/Decompressor.h
+++ b/src/compression/Decompressor.h
@@ -33,6 +33,9 @@
 
 #include "BasicTypes.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
+#include "ppcore/Descriptor.h"
+#include "PPSystemString.h"
 
 class XMFile;
 

--- a/src/fx/CMakeLists.txt
+++ b/src/fx/CMakeLists.txt
@@ -64,10 +64,31 @@ add_library(fx STATIC
     fpmath.h
 )
 
+set_target_properties(fx PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
 target_include_directories(fx
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../ppui/osinterface/posix
-        ${CMAKE_CURRENT_SOURCE_DIR}/../ppui
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${PROJECT_SOURCE_DIR}/src
+        ${PROJECT_SOURCE_DIR}/src/ppui
+)
+
+target_compile_options(fx
+    PRIVATE
+        -include cstring
+)
+
+target_compile_definitions(fx
+    PRIVATE
+        PP_INT64_TYPE=int64_t
+)
+
+target_link_libraries(fx
+    PRIVATE
+        ppcore
+        osinterface
 )

--- a/src/fx/FXAbstract.h
+++ b/src/fx/FXAbstract.h
@@ -31,7 +31,7 @@
 #ifndef FXABSTRACT__H
 #define FXABSTRACT__H
 
-#include "BasicTypes.h"
+#include "ppcore/BasicTypes.h"
 
 class FXAbstract
 {

--- a/src/fx/Filter.cpp
+++ b/src/fx/Filter.cpp
@@ -20,7 +20,8 @@
  *
  */
 
-#include "BasicTypes.h"
+#include <cstring>
+#include "ppcore/BasicTypes.h"
 #include "fpmath.h"
 #include "Filter.h"
 

--- a/src/fx/Fire.h
+++ b/src/fx/Fire.h
@@ -31,7 +31,7 @@
 #ifndef FIRE__H
 #define FIRE__H
 
-#include "BasicTypes.h"
+#include "ppcore/BasicTypes.h"
 #include "FXAbstract.h"
 
 class Fire : public FXAbstract

--- a/src/fx/Math3d.cpp
+++ b/src/fx/Math3d.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "Math3d.h"
+#include <cstring>
 
 /////////////////////
 // VectorFP struct //

--- a/src/fx/ParticleBlobs.cpp
+++ b/src/fx/ParticleBlobs.cpp
@@ -22,8 +22,10 @@
 
 #include "ParticleBlobs.h"
 #include "Math3d.h"
+#include "osinterface/PPSystem.h"
 #include "Filter.h"
 #include "Texture.h"
+#include <math.h>
 
 #define GRIDSIZE 8
 #define NUMPARTICLES (GRIDSIZE*GRIDSIZE*GRIDSIZE)

--- a/src/fx/TexturedGrid.cpp
+++ b/src/fx/TexturedGrid.cpp
@@ -22,6 +22,7 @@
 
 #include "TexturedGrid.h"
 #include "Math3d.h"
+#include "osinterface/PPSystem.h"
 #include "Filter.h"
 #include "Texture.h"
 #include <stdint.h>

--- a/src/fx/fpmath.cpp
+++ b/src/fx/fpmath.cpp
@@ -20,7 +20,9 @@
  *
  */
 
+#include <cstdint>
 #include "fpmath.h"
+#include "ppcore/BasicTypes.h"
 
 #ifdef _MIPS_
 extern "C" { // Use extern "c" fopp_int32r C++ file only 

--- a/src/fx/fpmath.h
+++ b/src/fx/fpmath.h
@@ -23,7 +23,7 @@
 #ifndef FPMATH_H
 #define FPMATH_H
 
-#include "BasicTypes.h"
+#include "ppcore/BasicTypes.h"
 
 #define fpceil(x) ((x+65535)>>16)
 

--- a/src/midi/CMakeLists.txt
+++ b/src/midi/CMakeLists.txt
@@ -34,6 +34,11 @@ target_include_directories(midi
         ${CMAKE_CURRENT_SOURCE_DIR}/../tracker
 )
 
+target_link_libraries(midi
+    PRIVATE
+        ppcore
+)
+
 # Add platform-specific sources and include paths
 if(APPLE)
     target_sources(midi PRIVATE

--- a/src/midi/osx/MidiReceiver_CoreMIDI.h
+++ b/src/midi/osx/MidiReceiver_CoreMIDI.h
@@ -25,6 +25,7 @@
 
 #include <CoreMIDI/CoreMIDI.h>
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
 
 class Tracker;
 class PPMutex;

--- a/src/ppcore/BasicTypes.h
+++ b/src/ppcore/BasicTypes.h
@@ -30,6 +30,8 @@ typedef unsigned short  pp_uint16;
 typedef signed short    pp_int16;
 typedef unsigned int    pp_uint32;
 typedef signed int      pp_int32;
+typedef signed long long pp_int64;
+typedef unsigned long long pp_uint64;
 
 // Basic structures needed by Dictionary
 struct PPPoint 
@@ -56,24 +58,121 @@ struct PPSize
     {
     }
     
-    PPSize(pp_int32 width, pp_int32 height) :
-        width(width), height(height)
+    PPSize(pp_int32 theWidth, pp_int32 theHeight) :
+        width(theWidth), height(theHeight)
     {
+    }
+
+    bool operator==(const PPSize& source) const
+    {
+        return (width == source.width && height == source.height);
+    }
+
+    bool operator!=(const PPSize& source) const
+    {
+        return !(width == source.width && height == source.height);
+    }
+
+    bool match(pp_int32 w, pp_int32 h) const
+    {
+        return width == w && height == h;
     }
 };
 
 struct PPRect 
 {
-    PPPoint position;
-    PPSize size;
+    pp_int32 x1, y1, x2, y2;
     
-    PPRect() 
+    PPRect() :
+        x1(0), y1(0), x2(0), y2(0)
     {
     }
     
     PPRect(const PPPoint& position, const PPSize& size) :
-        position(position), size(size)
+        x1(position.x), y1(position.y),
+        x2(position.x + size.width), y2(position.y + size.height)
     {
+    }
+
+    PPRect(pp_int32 x1, pp_int32 y1, pp_int32 x2, pp_int32 y2) :
+        x1(x1), y1(y1), x2(x2), y2(y2)
+    {
+    }
+
+    PPPoint getPosition() const { return PPPoint(x1, y1); }
+    PPSize getSize() const { return PPSize(x2 - x1, y2 - y1); }
+    pp_int32 width() const { return x2 - x1; }
+    pp_int32 height() const { return y2 - y1; }
+
+    void scale(pp_int32 factor)
+    {
+        x1 *= factor;
+        y1 *= factor;
+        x2 *= factor;
+        y2 *= factor;
+    }
+
+    bool intersect(const PPRect& r) const
+    {
+        return !(x2 < r.x1 || x1 > r.x2 || y2 < r.y1 || y1 > r.y2);
+    }
+};
+
+struct PPColor
+{
+    pp_uint8 r,g,b;
+    
+    PPColor() :
+        r(0), g(0), b(0)
+    {
+    }
+    
+    PPColor(pp_uint8 r, pp_uint8 g, pp_uint8 b) :
+        r(r), g(g), b(b)
+    {
+    }
+
+    void set(pp_uint8 _r, pp_uint8 _g, pp_uint8 _b)
+    {
+        r = _r;
+        g = _g;
+        b = _b;
+    }
+
+    void scaleFixed(pp_uint32 scale)
+    {
+        r = (pp_uint8)((scale * r) >> 16);
+        g = (pp_uint8)((scale * g) >> 16);
+        b = (pp_uint8)((scale * b) >> 16);
+    }
+
+    void scale(float factor)
+    {
+        r = (pp_uint8)(r * factor);
+        g = (pp_uint8)(g * factor);
+        b = (pp_uint8)(b * factor);
+    }
+
+    void scale(float rFactor, float gFactor, float bFactor)
+    {
+        r = (pp_uint8)(r * rFactor);
+        g = (pp_uint8)(g * gFactor);
+        b = (pp_uint8)(b * bFactor);
+    }
+
+    void clamp()
+    {
+        r = r > 255 ? 255 : r;
+        g = g > 255 ? 255 : g;
+        b = b > 255 ? 255 : b;
+    }
+
+    PPColor& operator+=(const PPColor& other)
+    {
+        r = (pp_uint8)((pp_uint32)r + other.r);
+        g = (pp_uint8)((pp_uint32)g + other.g);
+        b = (pp_uint8)((pp_uint32)b + other.b);
+        return *this;
     }
 };
 

--- a/src/ppcore/BasicTypes.h
+++ b/src/ppcore/BasicTypes.h
@@ -34,146 +34,182 @@ typedef signed long long pp_int64;
 typedef unsigned long long pp_uint64;
 
 // Basic structures needed by Dictionary
-struct PPPoint 
+struct PPPoint
 {
-    pp_int32 x, y;
-    
-    PPPoint() :
-        x(0), y(0)
-    {
-    }
-    
-    PPPoint(pp_int32 x, pp_int32 y) :
-        x(x), y(y)
-    {
-    }
+	pp_int32 x, y;
+
+	PPPoint(pp_int32 theX, pp_int32 theY) :
+		x(theX), y(theY)
+	{}
+	
+	PPPoint() 
+	{}
 };
 
-struct PPSize 
+struct PPSize
 {
-    pp_int32 width, height;
-    
-    PPSize() :
-        width(0), height(0)
-    {
-    }
-    
-    PPSize(pp_int32 theWidth, pp_int32 theHeight) :
-        width(theWidth), height(theHeight)
-    {
-    }
+	pp_int32 width, height;
 
-    bool operator==(const PPSize& source) const
-    {
-        return (width == source.width && height == source.height);
-    }
+	PPSize(pp_int32 theWidth, pp_int32 theHeight) :
+		width(theWidth), height(theHeight)
+	{}
+	
+	PPSize() 
+	{}
 
-    bool operator!=(const PPSize& source) const
-    {
-        return !(width == source.width && height == source.height);
-    }
-
-    bool match(pp_int32 w, pp_int32 h) const
-    {
-        return width == w && height == h;
-    }
+	bool operator==(const PPSize& source) const
+	{
+		return (width == source.width && height == source.height);
+	}
+	
+	bool operator!=(const PPSize& source) const
+	{
+		return !(width == source.width && height == source.height);
+	}
+	
+	bool match(pp_int32 width, pp_int32 height) const
+	{
+		return (this->width == width && this->height == height);
+	}
 };
 
-struct PPRect 
+struct PPRect
 {
-    pp_int32 x1, y1, x2, y2;
-    
-    PPRect() :
-        x1(0), y1(0), x2(0), y2(0)
-    {
-    }
-    
-    PPRect(const PPPoint& position, const PPSize& size) :
-        x1(position.x), y1(position.y),
-        x2(position.x + size.width), y2(position.y + size.height)
-    {
-    }
+	pp_int32 x1, y1, x2, y2;
 
-    PPRect(pp_int32 x1, pp_int32 y1, pp_int32 x2, pp_int32 y2) :
-        x1(x1), y1(y1), x2(x2), y2(y2)
-    {
-    }
+	PPRect(pp_int32 px1, pp_int32 py1, pp_int32 px2, pp_int32 py2) :
+		x1(px1), y1(py1), x2(px2), y2(py2)
+	{}
 
-    PPPoint getPosition() const { return PPPoint(x1, y1); }
-    PPSize getSize() const { return PPSize(x2 - x1, y2 - y1); }
-    pp_int32 width() const { return x2 - x1; }
-    pp_int32 height() const { return y2 - y1; }
+	PPRect()
+	{}
 
-    void scale(pp_int32 factor)
-    {
-        x1 *= factor;
-        y1 *= factor;
-        x2 *= factor;
-        y2 *= factor;
-    }
-
-    bool intersect(const PPRect& r) const
-    {
-        return !(x2 < r.x1 || x1 > r.x2 || y2 < r.y1 || y1 > r.y2);
-    }
+	pp_int32 width() const { return x2-x1; }
+	pp_int32 height() const { return y2-y1; }
+	
+	void scale(pp_int32 scaleFactor)
+	{
+		x1 *= scaleFactor;
+		y1 *= scaleFactor;
+		x2 *= scaleFactor;
+		y2 *= scaleFactor;
+	}
+	
+	bool intersect(const PPRect& rc) const
+	{
+		pp_int32 left1, left2;
+		pp_int32 right1, right2;
+		pp_int32 top1, top2;
+		pp_int32 bottom1, bottom2;
+		
+		left1 = this->x1;
+		left2 = rc.x1;
+		right1 = this->x1 + this->width();
+		right2 = rc.x1 + rc.width();
+		top1 = this->y1;
+		top2 = rc.y1;
+		bottom1 = this->y1 + this->height();
+		bottom2 = rc.y1 + rc.height();
+		
+		if (bottom1 < top2) return false;
+		if (top1 > bottom2) return false;
+		
+		if (right1 < left2) return false;
+		if (left1 > right2) return false;
+		
+		return true;
+	} 
+	
 };
 
 struct PPColor
 {
-    pp_uint8 r,g,b;
-    
-    PPColor() :
-        r(0), g(0), b(0)
-    {
-    }
-    
-    PPColor(pp_uint8 r, pp_uint8 g, pp_uint8 b) :
-        r(r), g(g), b(b)
-    {
-    }
+	pp_int32 r,g,b;
 
-    void set(pp_uint8 _r, pp_uint8 _g, pp_uint8 _b)
-    {
-        r = _r;
-        g = _g;
-        b = _b;
-    }
+	PPColor(pp_int32 red, pp_int32 green, pp_int32 blue) :
+		r(red), g(green), b(blue)
+	{}
 
-    void scaleFixed(pp_uint32 scale)
-    {
-        r = (pp_uint8)((scale * r) >> 16);
-        g = (pp_uint8)((scale * g) >> 16);
-        b = (pp_uint8)((scale * b) >> 16);
-    }
+	PPColor() :
+		r(), g(), b()
+	{}
+	
+	void validate()
+	{
+		if (r > 255) r = 255;
+		if (g > 255) g = 255;
+		if (b > 255) b = 255;
+	}
 
-    void scale(float factor)
-    {
-        r = (pp_uint8)(r * factor);
-        g = (pp_uint8)(g * factor);
-        b = (pp_uint8)(b * factor);
-    }
+	void scale(float f) 
+	{
+		r = (pp_int32)((float)r*f);
+		g = (pp_int32)((float)g*f);
+		b = (pp_int32)((float)b*f);
+		validate();
+	}
 
-    void scale(float rFactor, float gFactor, float bFactor)
-    {
-        r = (pp_uint8)(r * rFactor);
-        g = (pp_uint8)(g * gFactor);
-        b = (pp_uint8)(b * bFactor);
-    }
+	void scale(float fr, float fg, float fb) 
+	{
+		r = (pp_int32)((float)r*fr);
+		g = (pp_int32)((float)g*fg);
+		b = (pp_int32)((float)b*fb);
+		validate();
+	}
 
-    void clamp()
-    {
-        r = r > 255 ? 255 : r;
-        g = g > 255 ? 255 : g;
-        b = b > 255 ? 255 : b;
-    }
+	void scaleFixed(pp_int32 f) 
+	{
+		r = (r*f)>>16;
+		g = (g*f)>>16;
+		b = (b*f)>>16;
+		validate();
+	}
+	
+	void interpolateFixed(const PPColor& col, pp_int32 f)
+	{
+		r = (f*r + col.r*(65536-f)) >> 16;
+		g = (f*g + col.g*(65536-f)) >> 16;
+		b = (f*b + col.b*(65536-f)) >> 16;
+		validate();
+	}
 
-    PPColor& operator+=(const PPColor& other)
-    {
-        r = (pp_uint8)((pp_uint32)r + other.r);
-        g = (pp_uint8)((pp_uint32)g + other.g);
-        b = (pp_uint8)((pp_uint32)b + other.b);
-        return *this;
-    }
+	PPColor invert() const
+	{
+		PPColor c(255-r, 255-g, 255-b);
+		return c;
+	}
+
+	void set(pp_int32 red, pp_int32 green, pp_int32 blue)
+	{
+		r = red; g = green; b = blue;
+	}
+	
+	void clamp()
+	{
+		if (r < 0) r = 0;
+		if (g < 0) g = 0;
+		if (b < 0) b = 0;
+
+		validate();
+	}
+
+	void operator+=(const PPColor& source)
+	{
+		r+=source.r;
+		g+=source.g;
+		b+=source.b;
+		validate();
+	}
+	
+	bool operator==(const PPColor& source) const
+	{
+		return (r == source.r && g == source.g && b == source.b);
+	}
+	
+	bool operator!=(const PPColor& source) const
+	{
+		return !(r == source.r && g == source.g && b == source.b);
+	}
 };
 
 #endif 

--- a/src/ppcore/BasicTypes.h
+++ b/src/ppcore/BasicTypes.h
@@ -1,0 +1,80 @@
+/*
+ *  ppcore/BasicTypes.h
+ *
+ *  Copyright 2009 Peter Barth
+ *  Copyright 2024 Dale Whinham
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PPCORE_BASICTYPES__H
+#define PPCORE_BASICTYPES__H
+
+typedef unsigned char    pp_uint8;
+typedef signed char     pp_int8;
+typedef unsigned short  pp_uint16;
+typedef signed short    pp_int16;
+typedef unsigned int    pp_uint32;
+typedef signed int      pp_int32;
+
+// Basic structures needed by Dictionary
+struct PPPoint 
+{
+    pp_int32 x, y;
+    
+    PPPoint() :
+        x(0), y(0)
+    {
+    }
+    
+    PPPoint(pp_int32 x, pp_int32 y) :
+        x(x), y(y)
+    {
+    }
+};
+
+struct PPSize 
+{
+    pp_int32 width, height;
+    
+    PPSize() :
+        width(0), height(0)
+    {
+    }
+    
+    PPSize(pp_int32 width, pp_int32 height) :
+        width(width), height(height)
+    {
+    }
+};
+
+struct PPRect 
+{
+    PPPoint position;
+    PPSize size;
+    
+    PPRect() 
+    {
+    }
+    
+    PPRect(const PPPoint& position, const PPSize& size) :
+        position(position), size(size)
+    {
+    }
+};
+
+#endif 

--- a/src/ppcore/CMakeLists.txt
+++ b/src/ppcore/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+#  src/ppcore/CMakeLists.txt
+#
+#  Copyright 2024 Dale Whinham
+#
+#  This file is part of MilkyTracker.
+#
+#  MilkyTracker is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MilkyTracker is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with MilkyTracker.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+add_library(ppcore STATIC
+    BasicTypes.h
+    Dictionary.cpp
+    Dictionary.h
+    DictionaryKey.cpp
+    DictionaryKey.h
+    SimpleVector.h
+    Object.h
+)
+
+target_include_directories(ppcore
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+) 

--- a/src/ppcore/CMakeLists.txt
+++ b/src/ppcore/CMakeLists.txt
@@ -20,16 +20,27 @@
 #
 
 add_library(ppcore STATIC
-    BasicTypes.h
+    # Sources
     Dictionary.cpp
-    Dictionary.h
     DictionaryKey.cpp
+
+    # Headers
+    BasicTypes.h
+    Descriptor.h
+    Dictionary.h
     DictionaryKey.h
-    SimpleVector.h
     Object.h
+    PPString.h
+    SimpleVector.h
+)
+
+target_compile_definitions(ppcore
+    PUBLIC
+        __STDC_WANT_LIB_EXT1__=1  # For NULL and other standard definitions
 )
 
 target_include_directories(ppcore
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src
 ) 

--- a/src/ppcore/Descriptor.h
+++ b/src/ppcore/Descriptor.h
@@ -1,7 +1,8 @@
 /*
- *  tracker/TabTitleProvider.h
+ *  ppcore/Descriptor.h
  *
  *  Copyright 2009 Peter Barth
+ *  Copyright 2024 Dale Whinham
  *
  *  This file is part of Milkytracker.
  *
@@ -20,32 +21,21 @@
  *
  */
 
-/*
- *  TabTitleProvider.h
- *  MilkyTracker
- *
- *  Created by Peter Barth on 11.12.07.
- *
- */
+#ifndef PPCORE_DESCRIPTOR_H
+#define PPCORE_DESCRIPTOR_H
 
-#ifndef __TABTITLEPROVIDER_H__
-#define __TABTITLEPROVIDER_H__
+#include "PPSystemString.h"
 
-#include "BasicTypes.h"
-#include "ppcore/PPString.h"
-
-class TabTitleProvider
+struct Descriptor
 {
-private:
-	class ModuleEditor& moduleEditor;
+	PPSystemString description;
+	PPSystemString extension;
 
-public:
-	TabTitleProvider(ModuleEditor& moduleEditor) :
-		moduleEditor(moduleEditor)
+	Descriptor(const PPSystemString& ext, const PPSystemString& desc) :
+		description(desc),
+		extension(ext)
 	{
 	}
-	
-	PPString getTabTitle();
 };
 
-#endif
+#endif 

--- a/src/ppcore/Dictionary.cpp
+++ b/src/ppcore/Dictionary.cpp
@@ -1,0 +1,235 @@
+/*
+ *  ppui/Dictionary.cpp
+ *
+ *  Copyright 2009 Peter Barth
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  PPDictionary.cpp
+ *  MilkyTracker
+ *
+ *  Created by Peter Barth on Mon Mar 14 2005.
+ *
+ */
+
+#include "Dictionary.h"
+#include "SimpleVector.h"
+
+PPDictionary::PPDictionary() :
+	enumerating(false),
+	enumerationIndex(0)
+{
+	keys = new PPSimpleVector<PPDictionaryKey>;
+}
+
+PPDictionary::~PPDictionary()
+{
+	delete keys;
+}
+
+// copy c'tor
+PPDictionary::PPDictionary(const PPDictionary& source)
+{
+	keys = source.keys->clone();
+}
+
+PPDictionary& PPDictionary::operator=(const PPDictionary& source)
+{
+	// no self-assignment
+	if (this != &source)
+	{
+		delete keys;	
+		
+		keys = source.keys->clone();
+	}
+
+	return *this;
+}
+
+
+PPDictionaryKey* PPDictionary::getKeyToModify(const PPString& key) const
+{
+	for (pp_int32 i = 0;  i < keys->size(); i++)
+	{
+		PPDictionaryKey* theKey = keys->get(i);
+		if (theKey != NULL && theKey->getKey().compareTo(key) == 0)
+			return theKey;
+	}
+	return NULL;
+}
+
+void PPDictionary::store(const PPString& key, const PPString& value)
+{
+	PPDictionaryKey* theKey = getKeyToModify(key);
+	
+	if (theKey)
+		theKey->store(value);
+	else
+		keys->add(new PPDictionaryKey(key, value));
+}
+
+void PPDictionary::store(const PPString& key, const pp_uint32 value)
+{
+	PPDictionaryKey* theKey = getKeyToModify(key);
+	
+	if (theKey)
+		theKey->store(value);
+	else
+		keys->add(new PPDictionaryKey(key, value));
+}
+
+PPDictionaryKey* PPDictionary::restore(const PPString& key)
+{
+	return getKeyToModify(key);
+}
+
+pp_int32 PPDictionary::size() const
+{
+	return keys->size();
+}
+
+PPDictionaryKey* PPDictionary::getFirstKey()
+{
+	if (keys->size() == 0)
+		return NULL;
+		
+	enumerationIndex = 0;
+	enumerating = true;
+	PPDictionaryKey* theKey = keys->get(enumerationIndex);
+	enumerationIndex++;
+	return theKey;
+}
+
+PPDictionaryKey* PPDictionary::getNextKey()
+{
+	if (!enumerating)
+		return NULL;
+
+	PPDictionaryKey* theKey = keys->get(enumerationIndex);
+	enumerationIndex++;
+
+	if (enumerationIndex == keys->size())
+	{
+		enumerationIndex = 0;
+		enumerating = false;
+	}
+	
+	return theKey;
+}
+
+void PPDictionary::stopEnumeration()
+{
+	enumerating = false;
+	enumerationIndex = 0;
+}
+
+PPString PPDictionary::serializeToString()
+{
+	PPString result;
+	
+	for (pp_int32 i = 0; i < keys->size(); i++)
+	{
+		PPDictionaryKey* theKey = keys->get(i);
+	
+		if (i)
+			result.append(";");
+			
+		result.append(theKey->getKey());
+		result.append("=");
+		result.append(theKey->getStringValue());
+	}
+	
+	return result;
+}
+	
+PPDictionary* PPDictionary::createFromString(const PPString& string)
+{
+	PPDictionary* dictionary = new PPDictionary();
+
+	const char* str = string;
+
+	pp_uint32 index = 0;
+	
+	bool invalid = false;
+	
+	pp_uint32 startIndex = 0;
+	while (index < string.length())
+	{
+		while (str[index] && str[index] != '=')
+			index++;
+		
+		PPString key;
+		if (str[index] == '=')
+		{
+			key = string.subString(startIndex, index);
+			startIndex = ++index;
+		}
+		else
+		{
+			invalid = true;
+			break; 
+		}
+		
+		while (str[index] && str[index] != ';')
+			index++;
+		
+		PPString value;
+		if (index > startIndex)
+		{
+			value = string.subString(startIndex, index);
+			startIndex = ++index;
+		}
+		
+		dictionary->store(key, value);
+	}
+	
+	if (invalid || (string.length() == 0))
+	{
+		delete dictionary;
+		dictionary = NULL;
+	}
+	
+	return dictionary;
+}
+
+pp_uint32 PPDictionary::convertFloatToIntNonLossy(float value)
+{
+	pp_uint32 result;
+	
+	// not compatible
+	if (sizeof(float) != sizeof(result))
+		return 0;
+	
+	memcpy(&result, &value, sizeof(result));
+	
+	return result;
+}
+
+float PPDictionary::convertIntToFloatNonLossy(pp_uint32 value)
+{
+	float result;
+	
+	// not compatible
+	if (sizeof(float) != sizeof(result))
+		return 0;
+	
+	memcpy(&result, &value, sizeof(result));
+	
+	return result;
+}

--- a/src/ppcore/Dictionary.h
+++ b/src/ppcore/Dictionary.h
@@ -1,0 +1,79 @@
+/*
+ *  ppcore/Dictionary.h
+ *
+ *  Copyright 2009 Peter Barth
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  Dictionary.h
+ *  MilkyTracker
+ *
+ *  Created by Peter Barth on Mon Mar 14 2005.
+ *
+ */
+
+#ifndef DICTIONARY__H
+#define DICTIONARY__H
+
+#include "BasicTypes.h"
+#include "DictionaryKey.h"
+
+template<class Type>
+class PPSimpleVector;
+
+class PPDictionary
+{
+private:
+	PPSimpleVector<PPDictionaryKey>* keys;
+	
+	bool enumerating;
+	pp_int32 enumerationIndex;
+	
+	PPDictionaryKey* getKeyToModify(const PPString& key) const;
+	
+public:
+	PPDictionary();
+	~PPDictionary();
+	
+	// copy c'tor
+	PPDictionary(const PPDictionary& source);	
+
+	PPDictionary& operator=(const PPDictionary& source);
+	
+	void store(const PPString& key, const PPString& value);
+	void store(const PPString& key, const pp_uint32 value);
+	
+	PPDictionaryKey* restore(const PPString& key);
+	
+	pp_int32 size() const;
+
+	PPDictionaryKey* getFirstKey();
+	PPDictionaryKey* getNextKey();
+	void stopEnumeration();
+	
+	PPString serializeToString();
+	
+	static PPDictionary* createFromString(const PPString& string);
+	
+	static pp_uint32 convertFloatToIntNonLossy(float value);
+	static float convertIntToFloatNonLossy(pp_uint32 value);
+};
+
+#endif
+

--- a/src/ppcore/Dictionary.h
+++ b/src/ppcore/Dictionary.h
@@ -32,6 +32,7 @@
 #define DICTIONARY__H
 
 #include "BasicTypes.h"
+#include "PPString.h"
 #include "DictionaryKey.h"
 
 template<class Type>

--- a/src/ppcore/DictionaryKey.cpp
+++ b/src/ppcore/DictionaryKey.cpp
@@ -1,0 +1,73 @@
+/*
+ *  ppui/DictionaryKey.cpp
+ *
+ *  Copyright 2009 Peter Barth
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+ *  PPDictionaryKey.cpp
+ *  MilkyTracker
+ *
+ *  Created by Peter Barth on Mon Mar 14 2005.
+ *
+ */
+
+#include "DictionaryKey.h"
+#include <stdlib.h>
+
+PPDictionaryKey::PPDictionaryKey(const PPString& newKey, const PPString& newValue) :
+	key(newKey),
+	value(newValue)
+{
+}
+
+PPDictionaryKey::PPDictionaryKey(const PPString& newKey, const pp_uint32 value) :
+	key(newKey)
+{
+	store(value);
+}
+
+PPDictionaryKey::PPDictionaryKey(const PPDictionaryKey& source)
+{
+	key = source.key;
+	value = source.value;
+}
+
+void PPDictionaryKey::store(const PPString& newValue)
+{
+	value = newValue;
+}
+	
+void PPDictionaryKey::store(const pp_uint32 value)
+{
+	char buffer[100];
+	
+	sprintf(buffer,"%i",value);
+	
+	this->value = buffer;
+}
+
+pp_uint32 PPDictionaryKey::getIntValue() const
+{
+	pp_uint32 v; 
+	sscanf(value, "%i", &v);
+	
+	return v;
+}
+

--- a/src/ppcore/DictionaryKey.h
+++ b/src/ppcore/DictionaryKey.h
@@ -32,6 +32,7 @@
 #define DICTIONARYKEY__H
 
 #include "BasicTypes.h"
+#include "PPString.h"
 
 class PPDictionaryKey
 {

--- a/src/ppcore/DictionaryKey.h
+++ b/src/ppcore/DictionaryKey.h
@@ -1,8 +1,7 @@
 /*
- *  ppui/BasicTypes.h
+ *  ppcore/DictionaryKey.h
  *
  *  Copyright 2009 Peter Barth
- *  Copyright 2024 Dale Whinham
  *
  *  This file is part of Milkytracker.
  *
@@ -21,43 +20,43 @@
  *
  */
 
-#ifndef PPUI_BASICTYPES__H
-#define PPUI_BASICTYPES__H
+/*
+ *  DictionaryKey.h
+ *  MilkyTracker
+ *
+ *  Created by Peter Barth on Mon Mar 14 2005.
+ *
+ */
 
-// Include core types
-#include <ppcore/BasicTypes.h>
+#ifndef DICTIONARYKEY__H
+#define DICTIONARYKEY__H
 
-#if defined(WIN32) || defined(_WIN32_WCE) 
-	#include <windows.h>
-	#include <stdio.h>
-	#define VK_ALT        VK_MENU
-	#define __PPUI_WINDOWS__
-#endif
+#include "BasicTypes.h"
 
-#if !defined(__PPUI_WINDOWS__)
-	#include <stdio.h>
-	#include <stdlib.h>
-	#include <string.h>
-	#include "VirtualKeys.h"
-	#include "PPSystemString_POSIX.h"
-#endif
-
-// UI-specific types and includes
-#include "ScanCodes.h"
-
-struct PPColor
+class PPDictionaryKey
 {
-	pp_uint8 r,g,b;
+private:
+	PPString key;
+	PPString value;
 	
-	PPColor() :
-		r(0), g(0), b(0)
-	{
-	}
+public:
+	PPDictionaryKey(const PPString& newKey, const PPString& newValue);
+
+	PPDictionaryKey(const PPString& newKey, const pp_uint32 value);
+
+	// copy c'tor
+	PPDictionaryKey(const PPDictionaryKey& source);
 	
-	PPColor(pp_uint8 r, pp_uint8 g, pp_uint8 b) :
-		r(r), g(g), b(b)
-	{
-	}
+	void store(const PPString& newValue);
+	
+	void store(const pp_uint32 value);
+	
+	const PPString& getStringValue() const { return value; }
+	pp_uint32 getIntValue() const;
+	bool getBoolValue() const { return getIntValue() != 0; }
+
+	const PPString& getKey() const { return key; }
+
 };
 
 #endif

--- a/src/ppcore/Object.h
+++ b/src/ppcore/Object.h
@@ -1,8 +1,7 @@
 /*
- *  ppui/BasicTypes.h
+ *  ppui/Object.h
  *
  *  Copyright 2009 Peter Barth
- *  Copyright 2024 Dale Whinham
  *
  *  This file is part of Milkytracker.
  *
@@ -21,43 +20,11 @@
  *
  */
 
-#ifndef PPUI_BASICTYPES__H
-#define PPUI_BASICTYPES__H
+#ifndef OBJECT__H
+#define OBJECT__H
 
-// Include core types
-#include <ppcore/BasicTypes.h>
-
-#if defined(WIN32) || defined(_WIN32_WCE) 
-	#include <windows.h>
-	#include <stdio.h>
-	#define VK_ALT        VK_MENU
-	#define __PPUI_WINDOWS__
-#endif
-
-#if !defined(__PPUI_WINDOWS__)
-	#include <stdio.h>
-	#include <stdlib.h>
-	#include <string.h>
-	#include "VirtualKeys.h"
-	#include "PPSystemString_POSIX.h"
-#endif
-
-// UI-specific types and includes
-#include "ScanCodes.h"
-
-struct PPColor
+class PPObject
 {
-	pp_uint8 r,g,b;
-	
-	PPColor() :
-		r(0), g(0), b(0)
-	{
-	}
-	
-	PPColor(pp_uint8 r, pp_uint8 g, pp_uint8 b) :
-		r(r), g(g), b(b)
-	{
-	}
 };
 
 #endif

--- a/src/ppcore/PPString.h
+++ b/src/ppcore/PPString.h
@@ -1,0 +1,434 @@
+/*
+ *  ppcore/PPString.h
+ *
+ *  Copyright 2009 Peter Barth
+ *  Copyright 2024 Dale Whinham
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PPCORE_PPSTRING__H
+#define PPCORE_PPSTRING__H
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include "BasicTypes.h"
+
+#ifdef WIN32
+#define STRINGCOMPARE_NOCASE(left, right) _stricmp(left, right)
+#else
+#define STRINGCOMPARE_NOCASE(left, right) strcasecmp(left, right)
+#endif
+
+// C-String wrapper
+class PPString
+{
+private:
+    char* strBuffer;
+    pp_uint32 allocatedSize;
+
+    void reAlloc(pp_uint32 newSize)
+    {
+        if (newSize <= allocatedSize)
+            return;
+
+        char* newStrBuffer = new char[newSize];
+        memcpy(newStrBuffer, strBuffer, allocatedSize);
+
+        delete[] strBuffer;
+        strBuffer = newStrBuffer;
+        allocatedSize = newSize;
+    }
+
+public:
+    // Empty string
+    PPString() :
+        strBuffer(new char[8]),
+        allocatedSize(8)
+    {
+        *strBuffer = 0;        
+    }
+
+    // String from single character
+    PPString(char c) :
+        strBuffer(new char[8]),
+        allocatedSize(8)
+    {
+        *strBuffer = c;
+        *(strBuffer+1) = 0;
+    }
+
+    PPString(const char* str) :
+        strBuffer(new char[strlen(str) + 1]),
+        allocatedSize((pp_uint32)strlen(str) + 1)        
+    {
+        strcpy(strBuffer, str);        
+    }
+
+    PPString(const char* str, pp_uint32 length) :
+        strBuffer(new char[length + 1]),
+        allocatedSize(length + 1)
+    {
+        memcpy(strBuffer, str, length);
+        strBuffer[length] = 0;
+    }
+
+    // copy c'tor
+    PPString(const PPString& str) :
+        strBuffer(new char[str.allocatedSize]),
+        allocatedSize(str.allocatedSize)
+    {
+        memcpy(strBuffer, str.strBuffer, str.allocatedSize);
+    }
+
+    operator const char*() const
+    {
+        return strBuffer;
+    }
+
+    const char* getStrBuffer() const
+    {
+        return strBuffer;
+    }
+
+    // assignment operator
+    PPString& operator=(const PPString& str)
+    {
+        if (this != &str)
+        {
+            if (str.allocatedSize <= allocatedSize)
+            {
+                memcpy(strBuffer, str.strBuffer, str.allocatedSize);
+            }
+            else
+            {
+                delete[] strBuffer;            
+                strBuffer = new char[str.allocatedSize];
+                memcpy(strBuffer, str.strBuffer, str.allocatedSize);
+                allocatedSize = str.allocatedSize;
+            }
+        }
+    
+        return *this;
+    }
+
+    PPString& operator=(const char* str)
+    {
+        pp_uint32 len = (unsigned)strlen(str)+1;
+
+        if (len <= allocatedSize)
+        {
+            strcpy(strBuffer, str);
+        }
+        else
+        {
+            delete[] strBuffer;
+            strBuffer = new char[len];
+            strcpy(strBuffer, str);
+            allocatedSize = len;
+        }
+        
+        return *this;
+    }
+
+    // comparison is necessary too
+    bool operator==(const PPString& str) const
+    {
+        return strcmp(strBuffer, str.strBuffer) == 0;
+    }
+
+    bool operator!=(const PPString& str) const
+    {
+        return strcmp(strBuffer, str.strBuffer) != 0;
+    }
+
+    pp_int32 compareTo(const PPString& str) const
+    {
+        return strcmp(strBuffer, str.strBuffer);
+    }
+
+    pp_int32 compareToNoCase(const PPString& str) const
+    {
+        return STRINGCOMPARE_NOCASE(strBuffer, str.strBuffer);
+    }
+
+    bool startsWith(const PPString& str) const
+    {
+        if (length() < str.length())
+            return false;
+            
+        for (pp_uint32 i = 0; i < str.length(); i++)
+            if (strBuffer[i] != str.strBuffer[i])
+                return false;
+                
+        return true;
+    }
+    
+    ~PPString()
+    {
+        delete[] strBuffer;
+    }
+
+    pp_uint32 length() const
+    {
+        return (pp_uint32)strlen(strBuffer);
+    }
+
+    char charAt(pp_uint32 index) const
+    {
+        if (index < length())
+            return strBuffer[index];
+            
+        return 0;
+    }
+
+    void insertAt(pp_uint32 i, const PPString& s)
+    {
+        // doesn't work
+        if (i > length())
+            return;
+
+        allocatedSize = length() + s.length() + 1;
+
+        char* newStr = new char[allocatedSize];
+        
+        memcpy(newStr, strBuffer, i);
+        memcpy(newStr + i, s.strBuffer, s.length());
+        memcpy(newStr + i + s.length(), strBuffer + i, length() - i);
+        newStr[length() + s.length()] = 0;
+
+        delete[] strBuffer;
+
+        strBuffer = newStr;
+    }
+
+    void append(const PPString& s)
+    {
+        insertAt(length(), s);
+    }
+
+    void append(char c)
+    {
+        PPString s(c);
+        append(s);
+    }
+
+    void deleteAt(pp_uint32 i, pp_uint32 numChars)
+    {
+        // not possible
+        if (i > length())
+            return;
+
+        // nothing to delete
+        if ((signed)length() - (signed)numChars < 0)
+            return;
+
+        // nothing to delete
+        if (strBuffer[i] == 0)
+            return;
+
+        allocatedSize = length() - numChars + 1;
+
+        char* newStr = new char[allocatedSize];
+        
+        memcpy(newStr, strBuffer, i);
+        memcpy(newStr + i, strBuffer + i + numChars, length() - i - numChars);
+        newStr[length() - numChars] = 0;
+
+        delete[] strBuffer;
+
+        strBuffer = newStr;
+    }
+
+    PPString subString(pp_uint32 leftIndex, pp_uint32 rightIndex) const
+    {
+        PPString newString;
+        for (pp_uint32 i = leftIndex; i < rightIndex && i < length(); i++)
+            newString.append(charAt(i));
+        
+        return newString;
+    }
+
+    void replace(const PPString& str)
+    {
+        delete[] strBuffer;
+        strBuffer = new char[str.allocatedSize];
+        memcpy(strBuffer, str.strBuffer, str.allocatedSize);
+        allocatedSize = str.allocatedSize;
+    }
+
+    pp_int32 getIntValue() const
+    {
+        pp_uint32 v; 
+        sscanf(strBuffer, "%d", &v);
+        return v;
+    }
+    
+    pp_int32 countLines()
+    {
+        pp_int32 numLines = 1;
+        pp_int32 len = this->length();
+        for (pp_int32 i = 0; i < len; i++)
+        {
+            if (strBuffer[i] == '\n' && i != len-1)
+                numLines++;
+        }
+        
+        return numLines;
+    }
+
+    void toUpper()
+    {
+        for (pp_uint32 i = 0; i < length(); i++)
+            if (strBuffer[i] >= 'a' && 
+                strBuffer[i] <= 'z')
+                strBuffer[i] -= 'a'-'A';
+    }
+
+    void toLower()
+    {
+        for (pp_uint32 i = 0; i < length(); i++)
+            if (strBuffer[i] >= 'A' && 
+                strBuffer[i] <= 'Z')
+                strBuffer[i] += 'a'-'A';
+    }
+
+    PPString stripPath() const
+    {
+        char* ptr = strBuffer+strlen(strBuffer);
+        
+        while (ptr > strBuffer && *ptr != '/' && *ptr != '\\')
+            ptr--;
+            
+        if (ptr != strBuffer)
+            ptr++;
+            
+        PPString str = ptr;
+        return str;
+    }
+
+    PPString stripExtension() const
+    {
+        char* ptr = strBuffer+strlen(strBuffer);
+        
+        while (ptr > strBuffer && *ptr != '.' && *ptr != '/' && *ptr != '\\')
+            ptr--;
+        
+        if (*ptr == '/' || *ptr == '\\')
+            return strBuffer;
+            
+        if (ptr != strBuffer)
+        {    
+            PPString str;
+        
+            delete[] str.strBuffer;
+            str.allocatedSize = (pp_uint32)((ptr-strBuffer)+1);
+            str.strBuffer = new char[str.allocatedSize];
+            memcpy(str.strBuffer, strBuffer, (ptr-strBuffer));
+            str.strBuffer[(ptr-strBuffer)] = '\0';
+        
+            return str;
+        }
+        else
+        {
+            return ptr;
+        }
+    }
+
+    PPString getExtension() const
+    {
+        char* ptr = strBuffer+strlen(strBuffer);
+        
+        while (ptr > strBuffer && *ptr != '.' && *ptr != '/' && *ptr != '\\')
+            ptr--;
+        
+        if (*ptr != '.')
+            return "";
+            
+        return ptr;
+    }
+
+    pp_int32 compareExtensions(const PPString& str) const    
+    {
+        char* ptrSrc = strBuffer+strlen(strBuffer);
+        
+        while (ptrSrc > strBuffer && *ptrSrc != '.' && *ptrSrc != '/')
+            ptrSrc--;
+        
+        bool noExt1 = false;
+        
+        if (*ptrSrc != '.')
+            noExt1 = true;
+
+        ptrSrc++;
+        if (*ptrSrc == '\0')
+            noExt1 = true;
+
+        char* ptrDst = str.strBuffer+strlen(str.strBuffer);
+        
+        while (ptrDst > str.strBuffer && *ptrDst != '.' && *ptrDst != '/')
+            ptrDst--;
+        
+        if (*ptrDst != '.')
+            return noExt1 ? 0 : 1;
+
+        ptrDst++;
+        if (*ptrDst == '\0')
+            return noExt1 ? 0 : 1;
+
+        return STRINGCOMPARE_NOCASE(ptrSrc, ptrDst);
+    }
+
+    bool compareToExtension(const PPString& extension) const    
+    {
+        char* ptrSrc = strBuffer+strlen(strBuffer);
+        
+        while (ptrSrc > strBuffer && *ptrSrc != '.' && *ptrSrc != '/')
+            ptrSrc--;
+        
+        if (*ptrSrc != '.')
+            return false;
+
+        ptrSrc++;
+        if (*ptrSrc == '\0')
+            return false;
+
+        return STRINGCOMPARE_NOCASE(ptrSrc, extension.strBuffer) == 0;
+    }
+
+    void ensureTrailingCharacter(char chr)
+    {
+        pp_uint32 len = length();
+        if (len)
+        {
+            char* ptr = strBuffer+(len-1);
+            if (*ptr != chr)
+                append(chr);
+        }
+    }
+    
+    // Delete this pointer after usage
+    char* toASCIIZ() const
+    {
+        char* newStr = new char[length() + 1];
+        strcpy(newStr, strBuffer);
+        return newStr;
+    }
+};
+
+#endif 

--- a/src/ppcore/SimpleVector.h
+++ b/src/ppcore/SimpleVector.h
@@ -1,0 +1,256 @@
+/*
+ *  ppui/SimpleVector.h
+ *
+ *  Copyright 2009 Peter Barth
+ *
+ *  This file is part of Milkytracker.
+ *
+ *  Milkytracker is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Milkytracker is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Milkytracker.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef SIMPLEVECTOR__H
+#define SIMPLEVECTOR__H
+
+#include "BasicTypes.h"
+
+template<class Type>
+class PPSimpleVector
+{
+private:
+	pp_int32 numValuesAllocated;
+	Type** values;
+	pp_int32 numValues;
+	bool destroy;
+
+	void reallocate()
+	{
+		Type** values = new Type*[numValuesAllocated];
+		for (pp_int32 i = 0; i < numValues; i++)
+		{
+			values[i] = this->values[i];
+		}
+		delete[] this->values;		
+		this->values = values;
+	}
+
+	// no copy construction please
+	PPSimpleVector(const PPSimpleVector&);
+	PPSimpleVector& operator=(const PPSimpleVector&);
+	
+public:
+	PPSimpleVector(pp_int32 initialSize = 0, bool destroy = true)
+	{
+		this->destroy = destroy;
+
+		if (initialSize == 0)
+			initialSize = 16;
+
+		numValuesAllocated = initialSize;
+
+		if (initialSize)
+			values = new Type*[initialSize];
+		else
+			values = 0;
+
+		numValues = 0;
+	}
+
+	~PPSimpleVector()
+	{	
+		if (values)
+		{
+			if (destroy)
+				for (pp_int32 i = 0; i < numValues; i++)
+					delete values[i];
+
+			delete[] values;
+		}
+	}
+
+	PPSimpleVector* clone()
+	{
+		PPSimpleVector* clonedVector = new PPSimpleVector(numValuesAllocated, true);		
+		for (pp_int32 i = 0; i < numValues; i++)
+		{
+			clonedVector->values[i] = new Type(*values[i]);
+		}		
+		clonedVector->numValues = numValues;
+		return clonedVector;
+	}
+
+	void clear()
+	{
+		if (values)
+		{
+			if (destroy)
+				for (pp_int32 i = 0; i < numValues; i++)
+					delete values[i];
+
+			numValues = 0;
+		}
+	}
+
+	Type* removeNoDestroy(pp_int32 index)
+	{
+		if (!numValues)
+			return NULL;
+			
+		if (index < 0 || index >= numValues)
+			return NULL;
+			
+		Type* result = values[index];
+
+		for (pp_int32 i = index; i < numValues-1; i++)
+			values[i] = values[i+1];
+			
+		numValues--;
+		
+		if (numValuesAllocated - numValues > 16)
+		{
+			numValuesAllocated-=16;
+			reallocate();
+		}
+		
+		return result;
+	}
+
+	bool remove(pp_int32 index)
+	{
+		if (!numValues)
+			return false;
+			
+		if (index < 0 || index >= numValues)
+			return false;
+			
+		if (destroy)
+			delete values[index];
+
+		for (pp_int32 i = index; i < numValues-1; i++)
+			values[i] = values[i+1];
+			
+		numValues--;
+		
+		if (numValuesAllocated - numValues > 16)
+		{
+			numValuesAllocated-=16;
+			reallocate();
+		}
+		
+		return true;
+	}
+
+	void add(Type* value)
+	{
+		if (numValues >= numValuesAllocated)
+		{			
+			numValuesAllocated += 16;
+			reallocate();
+		}
+		values[numValues++] = value;
+	}
+
+	// handle with care
+	void replace(pp_int32 index, Type* value)
+	{
+		if (index < 0 || index >= numValues)
+			return;
+
+		if (destroy)
+			delete values[index];
+
+		values[index] = value;
+	}
+
+	Type* get(pp_int32 index) const
+	{
+		if (index < numValues)
+		{
+			return values[index];
+		}
+		else
+			return 0;
+	}
+
+	pp_int32 size() const { return numValues; }
+
+	bool isEmpty() const { return numValues == 0; }
+
+	// -- sorting --------------------------------------------------------------
+	struct SortRule
+	{
+		virtual pp_int32 compare(const Type& left, const Type& right) const = 0;
+	};
+	
+private:
+	static pp_int32 partition(Type** a, pp_int32 left, pp_int32 right, const SortRule& sortRule, bool descending = false)
+	{
+		const pp_int32 sign = descending ? -1 : 1;
+	
+		pp_int32 first=left, pivot=right--;
+		while(left<=right)
+		{
+			while(sortRule.compare(*a[left], *a[pivot])*sign < 0/*a[left]<a[pivot]*/)
+				left++;
+			
+			while((right>=first)&&(sortRule.compare(*a[right], *a[pivot])*sign >= 0/*a[right]>=a[pivot]*/))
+				right--;
+			
+			if(left<right)
+			{
+				swap(a, left,right);
+				left++;
+			}
+		}
+		if(left!=pivot)
+		swap(a, left,pivot);
+			
+		return left;
+	}
+			
+	static void swap(Type** a, pp_int32 i, pp_int32 j)
+	{
+		Type* temp=a[i];
+		a[i]=a[j];
+		a[j]=temp;
+	}
+			
+	static void sortInternal(Type** array, pp_int32 left, pp_int32 right, const SortRule& sortRule, bool descending = false)
+	{
+		pp_int32 p;
+		
+		if(left>=right)
+			return;
+		
+		p = partition(array, left, right, sortRule, descending);
+		
+		sortInternal(array, left,p-1, sortRule, descending);
+		sortInternal(array, p+1, right, sortRule, descending);
+	}
+
+public:
+	void sort(const SortRule& sortRule, pp_int32 l = 0, pp_int32 r = -1, const bool descending = false)
+	{
+		if (r == -1)
+			r = size()-1;
+	
+		// no need to sort
+		if (l == 0 && r <= 1)
+			return;
+		
+		sortInternal(values, l, r, sortRule, descending);
+	}	
+};
+
+#endif

--- a/src/ppcore/SimpleVector.h
+++ b/src/ppcore/SimpleVector.h
@@ -23,6 +23,7 @@
 #ifndef SIMPLEVECTOR__H
 #define SIMPLEVECTOR__H
 
+#include <cstddef>
 #include "BasicTypes.h"
 
 template<class Type>

--- a/src/ppui/BasicTypes.h
+++ b/src/ppui/BasicTypes.h
@@ -45,19 +45,4 @@
 // UI-specific types and includes
 #include "ScanCodes.h"
 
-struct PPColor
-{
-	pp_uint8 r,g,b;
-	
-	PPColor() :
-		r(0), g(0), b(0)
-	{
-	}
-	
-	PPColor(pp_uint8 r, pp_uint8 g, pp_uint8 b) :
-		r(r), g(g), b(b)
-	{
-	}
-};
-
 #endif

--- a/src/ppui/Button.h
+++ b/src/ppui/Button.h
@@ -28,9 +28,10 @@
 #ifndef BUTTON__H
 #define BUTTON__H
 
-#include "BasicTypes.h"
+#include "ppcore/PPString.h"
 #include "Control.h"
 #include "Event.h"
+#include "BasicTypes.h"
 
 // Forwards
 class PPGraphicsAbstract;

--- a/src/ppui/CMakeLists.txt
+++ b/src/ppui/CMakeLists.txt
@@ -112,6 +112,7 @@ target_include_directories(ppui
 target_link_libraries(ppui 
     PUBLIC 
         ppcore
+    PRIVATE
         osinterface
 )
 

--- a/src/ppui/CMakeLists.txt
+++ b/src/ppui/CMakeLists.txt
@@ -104,18 +104,30 @@ add_library(ppui STATIC
 
 target_include_directories(ppui
     PUBLIC
-        .
-    PRIVATE
-        osinterface
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/osinterface
+        ${CMAKE_CURRENT_SOURCE_DIR}/osinterface/posix
+        ${PROJECT_SOURCE_DIR}/src/ppcore
+        ${PROJECT_SOURCE_DIR}/src/ppui
+        ${PROJECT_SOURCE_DIR}/src/ppui/osinterface
+        ${PROJECT_SOURCE_DIR}/src/ppui/sdl
 )
 
-# Link against osinterface
-target_link_libraries(ppui 
-    PUBLIC 
+target_link_libraries(ppui
+    PUBLIC
         ppcore
-    PRIVATE
-        osinterface
 )
+
+# Add SDL2 for non-Apple, non-Windows platforms
+if(NOT APPLE AND NOT WIN32)
+    if(TARGET SDL2::SDL2)
+        target_link_libraries(ppui PUBLIC SDL2::SDL2)
+    else()
+        target_include_directories(ppui PUBLIC ${SDL2_INCLUDE_DIRS})
+        target_link_libraries(ppui PUBLIC ${SDL2_LIBRARIES})
+    endif()
+endif()
 
 # Add platform-specific sources and include paths
 if(APPLE)

--- a/src/ppui/CMakeLists.txt
+++ b/src/ppui/CMakeLists.txt
@@ -104,8 +104,9 @@ add_library(ppui STATIC
 
 target_include_directories(ppui
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/osinterface
+        .
+    PRIVATE
+        osinterface
 )
 
 # Link against osinterface
@@ -128,7 +129,6 @@ if(APPLE)
             ${PROJECT_SOURCE_DIR}/src/tracker/cocoa
         PUBLIC
             cocoa
-            ${CMAKE_CURRENT_SOURCE_DIR}/osinterface/posix
     )
 elseif(WIN32)
     target_sources(ppui
@@ -142,13 +142,6 @@ elseif(WIN32)
         PUBLIC
             win32
     )
-
-    if(TARGET SDL2::SDL2)
-        target_link_libraries(ppui PUBLIC SDL2::SDL2)
-    else()
-        target_include_directories(ppui PUBLIC ${SDL2_INCLUDE_DIRS})
-        target_link_libraries(ppui PUBLIC ${SDL2_LIBRARIES})
-    endif()
 else()
     target_sources(ppui
         PRIVATE
@@ -160,20 +153,7 @@ else()
             sdl/DisplayDeviceFB_SDL.h
             sdl/DisplayDevice_SDL.h
     )
-    target_include_directories(ppui 
-        PUBLIC 
-            sdl
-            ${CMAKE_CURRENT_SOURCE_DIR}/osinterface/posix
-    )
-
-    if(TARGET SDL2::SDL2)
-        # If the distro built SDL2 with CMake, we can just link to an exported target
-        target_link_libraries(ppui PUBLIC SDL2::SDL2)
-    else()
-        # Otherwise we need to do things the old-fashioned way for compatibility
-        target_include_directories(ppui PUBLIC ${SDL2_INCLUDE_DIRS})
-        target_link_libraries(ppui PUBLIC ${SDL2_LIBRARIES})
-    endif()
+    target_include_directories(ppui PUBLIC sdl)
 endif()
 
 if(APPLE)

--- a/src/ppui/CMakeLists.txt
+++ b/src/ppui/CMakeLists.txt
@@ -109,7 +109,11 @@ target_include_directories(ppui
 )
 
 # Link against osinterface
-target_link_libraries(ppui PUBLIC osinterface)
+target_link_libraries(ppui 
+    PUBLIC 
+        ppcore
+        osinterface
+)
 
 # Add platform-specific sources and include paths
 if(APPLE)
@@ -139,10 +143,8 @@ elseif(WIN32)
     )
 
     if(TARGET SDL2::SDL2)
-        # If the distro built SDL2 with CMake, we can just link to an exported target
         target_link_libraries(ppui PUBLIC SDL2::SDL2)
     else()
-        # Otherwise we need to do things the old-fashioned way for compatibility
         target_include_directories(ppui PUBLIC ${SDL2_INCLUDE_DIRS})
         target_link_libraries(ppui PUBLIC ${SDL2_LIBRARIES})
     endif()

--- a/src/ppui/CheckBoxLabel.cpp
+++ b/src/ppui/CheckBoxLabel.cpp
@@ -1,7 +1,7 @@
 /*
 *  ppui/CheckBoxLabel.h
 *
-*  Copyright 2017 Henri Isoj�rvi
+*  Copyright 2017 Henri Isojärvi
 *
 *  This file is part of Milkytracker.
 *

--- a/src/ppui/CheckBoxLabel.cpp
+++ b/src/ppui/CheckBoxLabel.cpp
@@ -1,7 +1,7 @@
 /*
 *  ppui/CheckBoxLabel.h
 *
-*  Copyright 2017 Henri Isojärvi
+*  Copyright 2017 Henri Isojï¿½rvi
 *
 *  This file is part of Milkytracker.
 *
@@ -21,6 +21,8 @@
 */
 
 #include "CheckBoxLabel.h"
+#include "Event.h"
+#include "CheckBox.h"
 
 PPCheckBoxLabel::PPCheckBoxLabel(pp_int32 id, PPScreen* parentScreen, EventListenerInterface* eventListener, 
 	const PPPoint& location, 

--- a/src/ppui/CheckBoxLabel.h
+++ b/src/ppui/CheckBoxLabel.h
@@ -1,7 +1,7 @@
 /*
 *  ppui/CheckBoxLabel.h
 *
-*  Copyright 2017 Henri Isoj�rvi
+*  Copyright 2017 Henri Isojärvi
 *
 *  This file is part of Milkytracker.
 *

--- a/src/ppui/CheckBoxLabel.h
+++ b/src/ppui/CheckBoxLabel.h
@@ -1,7 +1,7 @@
 /*
 *  ppui/CheckBoxLabel.h
 *
-*  Copyright 2017 Henri Isojärvi
+*  Copyright 2017 Henri Isojï¿½rvi
 *
 *  This file is part of Milkytracker.
 *
@@ -29,7 +29,9 @@
 #define CHECKBOXLABEL__H
 
 #include "StaticText.h"
-#include "CheckBox.h"
+#include "ppcore/PPString.h"
+
+class PPCheckBox;
 
 class PPCheckBoxLabel : public PPStaticText
 {

--- a/src/ppui/Control.h
+++ b/src/ppui/Control.h
@@ -97,9 +97,7 @@ public:
 
 	PPRect getBoundingRect() const
 	{
-		PPRect result(location.x, location.y, 
-					  location.x + size.width, location.y + size.height);
-		return result;
+		return PPRect(location, size);
 	}
 
 	pp_int32 getID() const { return id; }

--- a/src/ppui/Control.h
+++ b/src/ppui/Control.h
@@ -97,7 +97,9 @@ public:
 
 	PPRect getBoundingRect() const
 	{
-		return PPRect(location, size);
+		PPRect result(location.x, location.y, 
+					  location.x + size.width, location.y + size.height);
+		return result;
 	}
 
 	pp_int32 getID() const { return id; }

--- a/src/ppui/DialogBase.h
+++ b/src/ppui/DialogBase.h
@@ -33,6 +33,7 @@
 
 #include "BasicTypes.h"
 #include "Event.h"
+#include "ppcore/PPString.h"
 
 class PPScreen;
 class PPMessageBoxContainer;

--- a/src/ppui/DialogFileSelector.cpp
+++ b/src/ppui/DialogFileSelector.cpp
@@ -544,7 +544,7 @@ void DialogFileSelector::next()
 	refresh();
 }
 
-void DialogFileSelector::addExtension(const PPString& ext, const PPString& desc)
+void DialogFileSelector::addExtension(const PPSystemString& ext, const PPSystemString& desc)
 {
 	extensions.add(new Descriptor(ext, desc));
 }
@@ -555,7 +555,6 @@ void DialogFileSelector::refreshExtensions()
 
 	for (pp_int32 i = 0; i < extensions.size(); i++)
 		listBoxFiles->addExtension(extensions.get(i)->extension, extensions.get(i)->description);
-		
 }
 
 void DialogFileSelector::updateFilter()

--- a/src/ppui/DialogFileSelector.h
+++ b/src/ppui/DialogFileSelector.h
@@ -33,6 +33,7 @@
 
 #include "DialogBase.h"
 #include "SimpleVector.h"
+#include "ppcore/Descriptor.h"
 
 class PPListBoxFileBrowser;
 class PPListBox;
@@ -94,7 +95,7 @@ public:
 
 	void setCurrentEditFileName(const PPSystemString& name);	
 	
-	void addExtension(const PPString& ext, const PPString& desc);
+	void addExtension(const PPSystemString& ext, const PPSystemString& desc);
 
 private:	
 	void updateButtonStates(bool repaint = true);

--- a/src/ppui/Dictionary.h
+++ b/src/ppui/Dictionary.h
@@ -33,6 +33,7 @@
 
 #include "BasicTypes.h"
 #include "DictionaryKey.h"
+#include "ppcore/PPString.h"
 
 template<class Type>
 class PPSimpleVector;

--- a/src/ppui/DictionaryKey.h
+++ b/src/ppui/DictionaryKey.h
@@ -32,6 +32,7 @@
 #define DICTIONARYKEY__H
 
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
 
 class PPDictionaryKey
 {

--- a/src/ppui/DisplayDeviceBase.h
+++ b/src/ppui/DisplayDeviceBase.h
@@ -34,6 +34,7 @@
 
 #include "BasicTypes.h"
 #include "Font.h"
+#include "VirtualKeys.h"
 
 class PPGraphicsAbstract;
 

--- a/src/ppui/Font.h
+++ b/src/ppui/Font.h
@@ -27,6 +27,7 @@
 #define FONT__H
 
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
 #include "SimpleVector.h"
 
 #define MAXFONTS 256

--- a/src/ppui/GraphicsAbstract.h
+++ b/src/ppui/GraphicsAbstract.h
@@ -186,9 +186,10 @@ protected:
 			(currentClipRect.y1 > height && currentClipRect.y2 > height))
 		{
 			currentClipRect.x1 = 0;
-			currentClipRect.y1 = 0;
 			currentClipRect.x2 = 0;
+			currentClipRect.y1 = 0;
 			currentClipRect.y2 = 0;
+			return;
 		}
 	
 		if (currentClipRect.x1 < 0)
@@ -221,7 +222,7 @@ public:
 
 	void setRect(pp_int32 x1, pp_int32 y1, pp_int32 x2, pp_int32 y2) 
 	{ 
-		currentClipRect = PPRect(x1, y1, x2, y2);
+		currentClipRect.x1 = x1; currentClipRect.y1 = y1; currentClipRect.x2 = x2; currentClipRect.y2 = y2; 
 		origRect = currentClipRect;
 		validateRect();
 	}

--- a/src/ppui/GraphicsAbstract.h
+++ b/src/ppui/GraphicsAbstract.h
@@ -186,10 +186,9 @@ protected:
 			(currentClipRect.y1 > height && currentClipRect.y2 > height))
 		{
 			currentClipRect.x1 = 0;
-			currentClipRect.x2 = 0;
 			currentClipRect.y1 = 0;
+			currentClipRect.x2 = 0;
 			currentClipRect.y2 = 0;
-			return;
 		}
 	
 		if (currentClipRect.x1 < 0)
@@ -222,7 +221,7 @@ public:
 
 	void setRect(pp_int32 x1, pp_int32 y1, pp_int32 x2, pp_int32 y2) 
 	{ 
-		currentClipRect.x1 = x1; currentClipRect.y1 = y1; currentClipRect.x2 = x2; currentClipRect.y2 = y2; 
+		currentClipRect = PPRect(x1, y1, x2, y2);
 		origRect = currentClipRect;
 		validateRect();
 	}

--- a/src/ppui/ListBox.h
+++ b/src/ppui/ListBox.h
@@ -32,10 +32,11 @@
 #include "Control.h"
 #include "Event.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
+#include "ScrollBar.h"
 
 // Forwards
 class PPGraphicsAbstract;
-class PPScrollbar;
 class PPFont;
 class PPButton;
 

--- a/src/ppui/ListBoxFileBrowser.cpp
+++ b/src/ppui/ListBoxFileBrowser.cpp
@@ -72,10 +72,10 @@ void PPListBoxFileBrowser::clearExtensions()
 void PPListBoxFileBrowser::addExtensions(const char* const extensions[])
 {
 	for (pp_uint32 i = 0; extensions[i] != NULL; i+=2)
-		addExtension(extensions[i], extensions[i+1]);
+		addExtension(PPSystemString(extensions[i]), PPSystemString(extensions[i+1]));
 }
 
-void PPListBoxFileBrowser::addExtension(const PPString& ext, const PPString& desc)
+void PPListBoxFileBrowser::addExtension(const PPSystemString& ext, const PPSystemString& desc)
 {
 	Descriptor* d = new Descriptor(ext, desc);
 	items.add(d);

--- a/src/ppui/ListBoxFileBrowser.h
+++ b/src/ppui/ListBoxFileBrowser.h
@@ -33,6 +33,7 @@
 #include "ListBox.h"
 #include "SimpleVector.h"
 #include "UndoStack.h"
+#include "ppcore/Descriptor.h"
 
 class PPListBoxFileBrowser : public PPListBox
 {
@@ -42,6 +43,7 @@ public:
 		SortByName,
 		SortBySize,
 		SortByExtension,
+		
 		NumSortRules
 	};
 
@@ -89,7 +91,7 @@ public:
 	// must contain pairs of extensions / description
 	// terminated by TWO NULL pointers
 	void addExtensions(const char* const extensions[]);
-	void addExtension(const PPString& ext, const PPString& desc);
+	void addExtension(const PPSystemString& ext, const PPSystemString& desc);
 	
 	const PPPath& getCurrentPath() const { return *currentPath; }
 	PPSystemString getCurrentPathAsString() const;

--- a/src/ppui/Menu.h
+++ b/src/ppui/Menu.h
@@ -33,6 +33,7 @@
 
 #include "BasicTypes.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
 
 class PPFont;
 class PPGraphicsAbstract;

--- a/src/ppui/PPSystemString.h
+++ b/src/ppui/PPSystemString.h
@@ -1,7 +1,7 @@
 /*
- *  tracker/TabTitleProvider.h
+ *  ppui/PPSystemString.h
  *
- *  Copyright 2009 Peter Barth
+ *  Copyright 2023 
  *
  *  This file is part of Milkytracker.
  *
@@ -20,32 +20,13 @@
  *
  */
 
-/*
- *  TabTitleProvider.h
- *  MilkyTracker
- *
- *  Created by Peter Barth on 11.12.07.
- *
- */
+#ifndef PPUI_SYSTEMSTRING_H
+#define PPUI_SYSTEMSTRING_H
 
-#ifndef __TABTITLEPROVIDER_H__
-#define __TABTITLEPROVIDER_H__
-
-#include "BasicTypes.h"
-#include "ppcore/PPString.h"
-
-class TabTitleProvider
-{
-private:
-	class ModuleEditor& moduleEditor;
-
-public:
-	TabTitleProvider(ModuleEditor& moduleEditor) :
-		moduleEditor(moduleEditor)
-	{
-	}
-	
-	PPString getTabTitle();
-};
-
+#ifdef WIN32
+#include "osinterface/win32/PPSystemString_WIN32.h"
+#else
+#include "osinterface/posix/PPSystemString_POSIX.h"
 #endif
+
+#endif 

--- a/src/ppui/RadioGroup.h
+++ b/src/ppui/RadioGroup.h
@@ -31,6 +31,7 @@
 #include "BasicTypes.h"
 #include "Control.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
 
 // Forwards
 class PPGraphicsAbstract;

--- a/src/ppui/Singleton.h
+++ b/src/ppui/Singleton.h
@@ -31,6 +31,8 @@
 #ifndef __SINGLETON_H__
 #define __SINGLETON_H__
 
+#include <cstddef>
+
 template<class type>
 class PPSingleton
 {

--- a/src/ppui/StaticText.h
+++ b/src/ppui/StaticText.h
@@ -30,6 +30,7 @@
 
 #include "BasicTypes.h"
 #include "Control.h"
+#include "ppcore/PPString.h"
 
 // Forwards
 class PPGraphicsAbstract;

--- a/src/ppui/Tools.h
+++ b/src/ppui/Tools.h
@@ -25,6 +25,7 @@
 
 #include "BasicTypes.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
 
 class PPTools
 {

--- a/src/ppui/VirtualKeys.h
+++ b/src/ppui/VirtualKeys.h
@@ -28,12 +28,17 @@
  *
  */
 
-#ifndef VIRTUALKEYS__H
-#define VIRTUALKEYS__H
+#ifndef __VIRTUALKEYS_H__
+#define __VIRTUALKEYS_H__
+
+// Little helper macro
+#define PPSTR_PERIODS "\xef"
 
 // These might look familiar to windows programmers ;)
 enum
 {
+	VK_NONE = 0,
+	
 	VK_UNDEFINED =     0x00,
 	
 	VK_LBUTTON =       0x01,

--- a/src/ppui/osinterface/CMakeLists.txt
+++ b/src/ppui/osinterface/CMakeLists.txt
@@ -65,9 +65,9 @@ if(APPLE)
             ${PROJECT_SOURCE_DIR}/src/tracker/cocoa
     )
     
-    # Link against Cocoa framework and make osinterface PUBLIC
+    # Link against Cocoa framework
     target_link_libraries(osinterface 
-        PUBLIC 
+        PRIVATE 
             "-framework Cocoa"
     )
 elseif(WIN32)

--- a/src/ppui/osinterface/CMakeLists.txt
+++ b/src/ppui/osinterface/CMakeLists.txt
@@ -36,9 +36,23 @@ add_library(osinterface STATIC
 target_include_directories(osinterface
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/src
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
+
+target_link_libraries(osinterface
+    PUBLIC
+        ppcore
+        ppui
+)
+
+if(NOT APPLE AND NOT WIN32)
+    target_link_libraries(osinterface
+        PUBLIC
+            SDL2::SDL2
+    )
+endif()
 
 # Add platform-specific sources and include paths
 if(APPLE)
@@ -92,22 +106,23 @@ else()
             # Sources
             posix/PPPath_POSIX.cpp
             posix/PPSystem_POSIX.cpp
+            posix/PPMutex.cpp
             sdl/PPMessageBox_SDL.cpp
-            sdl/PPMutex.cpp
             sdl/PPOpenPanel_SDL.cpp
-            sdl/PPQuitSaveAlert_SDL.cpp
             sdl/PPSavePanel_SDL.cpp
+            sdl/PPQuitSaveAlert_SDL.cpp
             sdl/SDL_ModalLoop.cpp
+            sdl/PPMutex.cpp
 
             # Headers
             posix/PPMutex.h
             posix/PPPath_POSIX.h
             posix/PPSystemString_POSIX.h
             posix/PPSystem_POSIX.h
-            sdl/PPMutex.h
             sdl/SDL_ModalLoop.h
+            sdl/PPMutex.h
     )
-    target_include_directories(osinterface PUBLIC posix)
+    target_include_directories(osinterface PUBLIC posix sdl)
 
     if(TARGET SDL2::SDL2)
         # If the distro built SDL2 with CMake, we can just link to an exported target

--- a/src/ppui/osinterface/CMakeLists.txt
+++ b/src/ppui/osinterface/CMakeLists.txt
@@ -60,15 +60,8 @@ if(APPLE)
             posix/PPSystem_POSIX.h
     )
     target_include_directories(osinterface 
-        PUBLIC 
-            posix
-            ${PROJECT_SOURCE_DIR}/src/tracker/cocoa
-    )
-    
-    # Link against Cocoa framework
-    target_link_libraries(osinterface 
         PRIVATE 
-            "-framework Cocoa"
+            posix
     )
 elseif(WIN32)
     target_sources(osinterface
@@ -93,7 +86,6 @@ elseif(WIN32)
     target_include_directories(osinterface
         PRIVATE
             ${PROJECT_SOURCE_DIR}/src/milkyplay
-        PUBLIC
             win32
     )
 else()
@@ -117,15 +109,15 @@ else()
             sdl/PPMutex.h
             sdl/SDL_ModalLoop.h
     )
-    target_include_directories(osinterface PUBLIC posix)
+    target_include_directories(osinterface PRIVATE posix)
 
     if(TARGET SDL2::SDL2)
         # If the distro built SDL2 with CMake, we can just link to an exported target
-        target_link_libraries(osinterface PUBLIC SDL2::SDL2)
+        target_link_libraries(osinterface PRIVATE SDL2::SDL2)
     else()
         # Otherwise we need to do things the old-fashioned way for compatibility
-        target_include_directories(osinterface PUBLIC ${SDL2_INCLUDE_DIRS})
-        target_link_libraries(osinterface PUBLIC ${SDL2_LIBRARIES})
+        target_include_directories(osinterface PRIVATE ${SDL2_INCLUDE_DIRS})
+        target_link_libraries(osinterface PRIVATE ${SDL2_LIBRARIES})
     endif()
 endif()
 

--- a/src/ppui/osinterface/CMakeLists.txt
+++ b/src/ppui/osinterface/CMakeLists.txt
@@ -59,10 +59,7 @@ if(APPLE)
             posix/PPSystemString_POSIX.h
             posix/PPSystem_POSIX.h
     )
-    target_include_directories(osinterface 
-        PRIVATE 
-            posix
-    )
+    target_include_directories(osinterface PUBLIC posix)
 elseif(WIN32)
     target_sources(osinterface
         PRIVATE
@@ -86,6 +83,7 @@ elseif(WIN32)
     target_include_directories(osinterface
         PRIVATE
             ${PROJECT_SOURCE_DIR}/src/milkyplay
+        PUBLIC
             win32
     )
 else()
@@ -109,15 +107,15 @@ else()
             sdl/PPMutex.h
             sdl/SDL_ModalLoop.h
     )
-    target_include_directories(osinterface PRIVATE posix)
+    target_include_directories(osinterface PUBLIC posix)
 
     if(TARGET SDL2::SDL2)
         # If the distro built SDL2 with CMake, we can just link to an exported target
-        target_link_libraries(osinterface PRIVATE SDL2::SDL2)
+        target_link_libraries(osinterface PUBLIC SDL2::SDL2)
     else()
         # Otherwise we need to do things the old-fashioned way for compatibility
-        target_include_directories(osinterface PRIVATE ${SDL2_INCLUDE_DIRS})
-        target_link_libraries(osinterface PRIVATE ${SDL2_LIBRARIES})
+        target_include_directories(osinterface PUBLIC ${SDL2_INCLUDE_DIRS})
+        target_link_libraries(osinterface PUBLIC ${SDL2_LIBRARIES})
     endif()
 endif()
 

--- a/src/ppui/osinterface/PPOpenPanel.h
+++ b/src/ppui/osinterface/PPOpenPanel.h
@@ -25,6 +25,8 @@
 
 #include "PPModalDialog.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
+#include "ppcore/Descriptor.h"
 
 class PPOpenPanel : public PPModalDialog
 {
@@ -44,10 +46,10 @@ public:
 	virtual void addExtensions(const char* const extensions[])
 	{
 		for (pp_uint32 i = 0; extensions[i] != NULL; i+=2)
-			addExtension(extensions[i], extensions[i+1]);
+			addExtension(PPSystemString(extensions[i]), PPSystemString(extensions[i+1]));
 	}
 
-	virtual void addExtension(const PPString& ext, const PPString& desc);
+	virtual void addExtension(const PPSystemString& ext, const PPSystemString& desc);
 
 	virtual const PPSystemString& getFileName() { return fileName; }
 

--- a/src/ppui/osinterface/PPPathFactory.h
+++ b/src/ppui/osinterface/PPPathFactory.h
@@ -28,10 +28,10 @@
  *
  */
 
-#ifndef __PPPATHFACTORY_POSIX_H__
-#define __PPPATHFACTORY_POSIX_H__
+#ifndef __PPPATHFACTORY_H__
+#define __PPPATHFACTORY_H__
 
-#include "PPPath.h"
+#include "../PPPath.h"
 
 class PPPathFactory
 {

--- a/src/ppui/osinterface/cocoa/PPOpenPanel_COCOA.mm
+++ b/src/ppui/osinterface/cocoa/PPOpenPanel_COCOA.mm
@@ -85,7 +85,7 @@ PPOpenPanel::~PPOpenPanel()
 		delete caption;
 }
 
-void PPOpenPanel::addExtension(const PPString& ext, const PPString& desc)
+void PPOpenPanel::addExtension(const PPSystemString& ext, const PPSystemString& desc)
 {
 	Descriptor* d = new Descriptor(ext, desc);
 

--- a/src/ppui/osinterface/posix/PPSystemString_POSIX.h
+++ b/src/ppui/osinterface/posix/PPSystemString_POSIX.h
@@ -28,9 +28,11 @@
  *
  */
 
-#ifndef PPSYSTEMSTRING__H
-#define PPSYSTEMSTRING__H
+#ifndef PPUI_SYSTEMSTRING_POSIX_H
+#define PPUI_SYSTEMSTRING_POSIX_H
 
+#include <cstring>
+#include <strings.h>  // for strcasecmp
 #include "BasicTypes.h"
 
 class PPSystemString

--- a/src/ppui/osinterface/posix/PPSystem_POSIX.h
+++ b/src/ppui/osinterface/posix/PPSystem_POSIX.h
@@ -32,6 +32,9 @@
 #define SYSTEM_POSIX_H
 
 #include "../../../milkyplay/MilkyPlayCommon.h"
+#include "ppcore/BasicTypes.h"
+
+pp_uint32 PPGetTickCount();
 
 class System
 {

--- a/src/ppui/osinterface/sdl/PPOpenPanel_SDL.cpp
+++ b/src/ppui/osinterface/sdl/PPOpenPanel_SDL.cpp
@@ -46,7 +46,7 @@ PPOpenPanel::~PPOpenPanel()
 		delete[] caption;
 }
 
-void PPOpenPanel::addExtension(const PPString& ext, const PPString& desc)
+void PPOpenPanel::addExtension(const PPSystemString& ext, const PPSystemString& desc)
 {
 	Descriptor* d = new Descriptor(ext, desc);
 
@@ -56,13 +56,11 @@ void PPOpenPanel::addExtension(const PPString& ext, const PPString& desc)
 PPOpenPanel::ReturnCodes PPOpenPanel::runModal()
 {
 	// Create a message box (the message box will invoke the responder)
-	DialogFileSelector* dialog = new DialogFileSelector(screen, NULL, PP_DEFAULT_ID, this->caption);
+	DialogFileSelector* dialog = new DialogFileSelector(screen, NULL, PP_DEFAULT_ID, PPString(this->caption));
 
 	for (pp_int32 i = 0; i < items.size(); i++)
 	{
-		PPSystemString ext(items.get(i)->extension);
-		PPSystemString desc(items.get(i)->description);
-		dialog->addExtension(ext, desc);
+		dialog->addExtension(items.get(i)->extension, items.get(i)->description);
 	}
 
 	ReturnCodes result = SDL_runModalLoop(screen, dialog);

--- a/src/ppui/osinterface/sdl/PPSavePanel_SDL.cpp
+++ b/src/ppui/osinterface/sdl/PPSavePanel_SDL.cpp
@@ -36,14 +36,12 @@
 PPSavePanel::ReturnCodes PPSavePanel::runModal()
 {
 	// Create a message box (the message box will invoke the responder)
-	DialogFileSelector* dialog = new DialogFileSelector(screen, NULL, PP_DEFAULT_ID, this->caption, true, true);
+	DialogFileSelector* dialog = new DialogFileSelector(screen, NULL, PP_DEFAULT_ID, PPString(this->caption), true, true);
 	dialog->setCurrentEditFileName(defaultFileName);
 
 	for (pp_int32 i = 0; i < items.size(); i++)
 	{
-		PPSystemString ext(items.get(i)->extension);
-		PPSystemString desc(items.get(i)->description);
-		dialog->addExtension(ext, desc);
+		dialog->addExtension(items.get(i)->extension, items.get(i)->description);
 	}
 
 	ReturnCodes result = SDL_runModalLoop(screen, dialog);

--- a/src/tracker/AnimatedFXControl.cpp
+++ b/src/tracker/AnimatedFXControl.cpp
@@ -37,6 +37,7 @@
 #include "LogoSmall.h"
 #include "Tools.h"
 #include "version.h"
+#include "osinterface/posix/PPSystem_POSIX.h"
 
 #undef FXTOGGLE
 

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -151,6 +151,7 @@ target_include_directories(tracker
 target_link_libraries(tracker
     fx
     trackerlib
+    ppui
     osinterface
 )
 

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -31,12 +31,18 @@ target_include_directories(trackerlib
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${PROJECT_BINARY_DIR}/src/tracker
         ${PROJECT_SOURCE_DIR}/src
+        ${PROJECT_SOURCE_DIR}/src/ppcore
+        ${PROJECT_SOURCE_DIR}/src/ppui
+        ${PROJECT_SOURCE_DIR}/src/ppui/osinterface
+        ${PROJECT_SOURCE_DIR}/src/ppui/osinterface/posix
 )
 
 target_link_libraries(trackerlib
     PUBLIC
         ppcore
         milkyplay
+        ppui
+        osinterface
 )
 
 add_executable(tracker
@@ -146,6 +152,7 @@ target_include_directories(tracker
         ${CMAKE_CURRENT_SOURCE_DIR}
         # Include the CMake-generated version header from the build directory
         ${PROJECT_BINARY_DIR}/src/tracker
+        ${PROJECT_SOURCE_DIR}/src/fx
 )
 
 target_link_libraries(tracker

--- a/src/tracker/CMakeLists.txt
+++ b/src/tracker/CMakeLists.txt
@@ -31,24 +31,12 @@ target_include_directories(trackerlib
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${PROJECT_BINARY_DIR}/src/tracker
         ${PROJECT_SOURCE_DIR}/src
-        ${PROJECT_SOURCE_DIR}/src/ppui
-        ${PROJECT_SOURCE_DIR}/src/ppui/osinterface
 )
-
-if(WIN32)
-    target_include_directories(trackerlib PUBLIC
-        ${PROJECT_SOURCE_DIR}/src/ppui/osinterface/win32
-    )
-else()
-    target_include_directories(trackerlib PUBLIC
-        ${PROJECT_SOURCE_DIR}/src/ppui/osinterface/posix
-    )
-endif()
 
 target_link_libraries(trackerlib
     PUBLIC
+        ppcore
         milkyplay
-        ppui
 )
 
 add_executable(tracker

--- a/src/tracker/ColorExportImport.h
+++ b/src/tracker/ColorExportImport.h
@@ -33,6 +33,8 @@
 
 #include "BasicTypes.h"
 #include "ColorPaletteContainer.h"
+#include "ppcore/PPString.h"
+#include "PPSystemString.h"
 
 class ColorExportImport
 {

--- a/src/tracker/ColorPaletteContainer.h
+++ b/src/tracker/ColorPaletteContainer.h
@@ -32,6 +32,7 @@
 #define COLORPALETTECONTAINER__H
 
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
 
 // Verx simple color palette, limited colors
 struct TColorPalette

--- a/src/tracker/EnvelopeContainer.h
+++ b/src/tracker/EnvelopeContainer.h
@@ -32,6 +32,7 @@
 #define ENVELOPECONTAINER__H
 
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
 
 struct TEnvelope;
 

--- a/src/tracker/FileExtProvider.cpp
+++ b/src/tracker/FileExtProvider.cpp
@@ -114,7 +114,7 @@ const char* const* FileExtProvider::fillList(const char* const* baseList, Extens
 	
 	// misuse a decompressor to retrieve the file types it can decompress
 	// they're not ordered though
-	Decompressor decompressor("");
+	Decompressor decompressor(PPSystemString(""));
 
 	if (decompressor.doesServeHint((DecompressorBase::Hints)type))
 	{

--- a/src/tracker/FileExtProvider.h
+++ b/src/tracker/FileExtProvider.h
@@ -33,6 +33,7 @@
 
 #include "BasicTypes.h"
 #include "SimpleVector.h"
+#include "ppcore/PPString.h"
 
 class FileExtProvider
 {

--- a/src/tracker/FileIdentificator.h
+++ b/src/tracker/FileIdentificator.h
@@ -31,7 +31,9 @@
 #ifndef __FILEINDENTIFICATOR_H__
 #define __FILEINDENTIFICATOR_H__
 
+#include <cstddef>
 #include "BasicTypes.h"
+#include "PPSystemString.h"
 
 class XMFile;
 

--- a/src/tracker/ModuleEditor.h
+++ b/src/tracker/ModuleEditor.h
@@ -27,6 +27,7 @@
 #include "BasicTypes.h"
 #include "PatternEditorTools.h"
 #include "SongLengthEstimator.h"
+#include "PPSystemString.h"
 
 class XIInstrument;
 class PatternEditor;

--- a/src/tracker/ModuleServices.h
+++ b/src/tracker/ModuleServices.h
@@ -33,6 +33,7 @@
 
 #include "BasicTypes.h"
 #include "MilkyPlayCommon.h"
+#include "PPSystemString.h"
 
 class ModuleServices
 {
@@ -43,8 +44,8 @@ private:
 
 public:
 	ModuleServices(XModule& module) :
-		module(module),
-		estimatedSongLength(-1)
+			module(module),
+			estimatedSongLength(-1)
 	{
 	}
 	

--- a/src/tracker/PatternEditorTools.h
+++ b/src/tracker/PatternEditorTools.h
@@ -31,6 +31,7 @@
 #ifndef __PATTERNEDITORTOOLS_H__
 #define __PATTERNEDITORTOOLS_H__
 
+#include <cstddef>
 #include "BasicTypes.h"
 #include "MilkyPlayTypes.h"
 

--- a/src/tracker/PatternTools.h
+++ b/src/tracker/PatternTools.h
@@ -20,10 +20,13 @@
  *
  */
 
-#ifndef PATTERNTOOLS__H
-#define PATTERNTOOLS__H
+#ifndef PATTERNTOOLS_H
+#define PATTERNTOOLS_H
 
+#include <cstddef>
 #include "BasicTypes.h"
+
+class TXMPattern;
 
 #define TONOTE(octave, note) \
 ((((pp_uint8)(octave)*12 + (pp_uint8)(note)) + 1) < 97 ? (((pp_uint8)(octave)*12 + (pp_uint8)(note)) + 1) : -1)

--- a/src/tracker/TabManager.h
+++ b/src/tracker/TabManager.h
@@ -31,6 +31,7 @@
 #ifndef __TABMANAGER_H__
 #define __TABMANAGER_H__
 
+#include <cstddef>
 #include "BasicTypes.h"
 
 template<class Type>

--- a/src/tracker/Tracker.h
+++ b/src/tracker/Tracker.h
@@ -20,10 +20,12 @@
  *
  */
 
-#ifndef TRACKER__H
-#define TRACKER__H
+#ifndef TRACKER_H
+#define TRACKER_H
 
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
+#include "PPSystemString.h"
 #include "Event.h"
 #include "EditModes.h"
 #include "FileTypes.h"

--- a/src/tracker/TrackerConfig.h
+++ b/src/tracker/TrackerConfig.h
@@ -24,6 +24,8 @@
 #define TRACKERCONFIG__H
 
 #include "BasicTypes.h"
+#include "ppcore/PPString.h"
+#include "PPSystemString.h"
 
 #define NUMEFFECTMACROS 20
 

--- a/src/tracker/sdl/SDL_KeyTranslation.cpp
+++ b/src/tracker/sdl/SDL_KeyTranslation.cpp
@@ -40,6 +40,8 @@
  */
 
 #include "SDL_KeyTranslation.h"
+#include "ppui/ScanCodes.h"
+#include "ppui/VirtualKeys.h"
 
 pp_uint16 toVK(const SDL_Keysym& keysym)
 {


### PR DESCRIPTION
Introduce a new `ppcore` module and reorganise build dependencies to facilitate code reuse.

- Add new `ppcore` module and its build configuration.
- Move core types and utilities into `ppcore`.
- Update dependencies in `compression`, `fx`, and `midi` modules to use `ppcore`.